### PR TITLE
Import Pod::Usage where required

### DIFF
--- a/nagios_zonecheck.pl
+++ b/nagios_zonecheck.pl
@@ -31,6 +31,7 @@ use warnings;
 use strict;
 
 use Getopt::Long;
+use Pod::Usage;
 
 use Net::DNS 0.49;
 use Net::DNS::SEC 0.12;


### PR DESCRIPTION
`nagios_zonecheck.pl` uses `pod2usage()` without importing `Pod::Usage` first.